### PR TITLE
fix: should pass cache options when vcpkg install

### DIFF
--- a/.github/actions/docker-build-push/action.yml
+++ b/.github/actions/docker-build-push/action.yml
@@ -41,7 +41,7 @@ runs:
           docker build \
             --build-arg VCPKG_BINARY_SOURCES="clear;x-gha,readwrite" \
             --build-arg ACTIONS_CACHE_URL="${{ env.ACTIONS_CACHE_URL }}" \
-            --build-arg ACTIONS_CACHE_URL="${{ env.ACTIONS_RUNTIME_TOKEN }}" \
+            --build-arg ACTIONS_RUNTIME_TOKEN="${{ env.ACTIONS_RUNTIME_TOKEN }}" \
             -t "${{ inputs.registry }}/${{ inputs.image }}:${{ inputs.tag }}" ${{ inputs.context }}
         shell: ${{ inputs.shell }}
 

--- a/win-alrd-rsxe/Dockerfile
+++ b/win-alrd-rsxe/Dockerfile
@@ -1,5 +1,8 @@
 FROM ghcr.io/automesh-network/dockerfiles:win-dev-rust
 
+ARG VCPKG_BINARY_SOURCES=
+ARG ACTIONS_CACHE_URL=
+ARG ACTIONS_RUNTIME_TOKEN=
 RUN vcpkg install openssl:x64-windows openssl:x64-windows-static openssl:x64-windows-static-md
 RUN vcpkg install openssl:x86-windows openssl:x86-windows-static openssl:x86-windows-static-md
 RUN vcpkg install openssl:arm64-windows openssl:arm64-windows-static openssl:arm64-windows-static-md


### PR DESCRIPTION
vcpkg install should pass cache options not just when vcpkg installs.